### PR TITLE
Add abstract and bio for Ryan Whitehurst's talk

### DIFF
--- a/ignites/reproducible-infrastructure-with-terraform-and-puppet.md
+++ b/ignites/reproducible-infrastructure-with-terraform-and-puppet.md
@@ -5,16 +5,13 @@
 
 Whether you manage a single application with thousands of identical nodes or a collection of unique, single-purpose servers, reproducibility of your infrastructure is critical to testing, reliability, and disaster recovery. Every DevOps tool purports to solve this problem, but too often, it feels like your "automation" involves more checklists than code, and this struggle only gets worse when you try to combine multiple tools. Turns out, though, you actually can make the dream of reproducible infrastructure a reality.
 
-In this talk, we'll take a look at how to combine Terraform and Puppet to construct fully automated, reproducible infrastructure on AWS. We'll cover:
+This talk will cover an overview of some patterns for combining Terraform and Puppet to construct fully automated, reproducible infrastructure on AWS, including:
 
-* building Terraform configurations to deploy EC2 instances, security groups, EBS volumes, Elastic Load Balancers, and more.
-* setting up user data and cloud-init in AWS to prepare a new EC2 instance and run Puppet.
+* building Terraform configurations to create AWS resources.
+* setting up user data and cloud-init in AWS to connect a new EC2 instance to Puppet.
 * using autosign with JWT to securely connect nodes to Puppet without manual intervention.
-* configuring an application node from scratch with Puppet.
-* leveraging AWS Lambda and Terraform to destroy infrastructure, clean up PuppetDB, and reprovision.
+* cleanly destroying and reprovisioning infrastructure.
 * designing everything to allow deploying multiple separate clusters.
-
-
 
 
 ## Ryan Whitehurst

--- a/presentations/reproducible-infrastructure-with-terraform-and-puppet.md
+++ b/presentations/reproducible-infrastructure-with-terraform-and-puppet.md
@@ -1,0 +1,20 @@
+## Reproducible Infrastructure With Terraform and Puppet
+
+
+## Abstract
+
+Whether you manage a single application with thousands of identical nodes or a collection of unique, single-purpose servers, reproducibility of your infrastructure is critical to testing, reliability, and disaster recovery. Every DevOps tool purports to solve this problem, but too often, it feels like your "automation" involves more checklists than code, and this struggle only gets worse when you try to combine multiple tools. Turns out, though, you actually can make the dream of reproducible infrastructure a reality.
+
+In this talk, we'll take a look at how to combine Terraform and Puppet to construct fully automated, reproducible infrastructure on AWS. We'll cover:
+
+* building Terraform configurations to deploy EC2 instances, security groups, EBS volumes, Elastic Load Balancers, and more.
+* setting up user data and cloud-init in AWS to prepare a new EC2 instance and run Puppet.
+* using autosign with JWT to securely connect nodes to Puppet without manual intervention.
+* configuring an application node from scratch with Puppet.
+* leveraging AWS Lambda and Terraform to destroy infrastructure, clean up PuppetDB, and reprovision.
+* designing everything to allow deploying multiple separate clusters.
+
+
+
+
+## Ryan Whitehurst

--- a/speaker/ryan-whitehurst.md
+++ b/speaker/ryan-whitehurst.md
@@ -2,4 +2,4 @@
 
 ## Bio
 
-Ryan Whitehurst is a Site Reliability Engineer at Puppet. He helps to keep the company's public web infrastructure online, as well as building and maintaining an internal OpenShift-based application platform. In the past, he worked as a web developer, and previously maintained the internal Puppet infrastructure at Puppet. He uses the handle `thrnio` in various places around the internet.
+Ryan Whitehurst is a Software Engineer in the Site Reliability Engineering group at Puppet. He helps to keep the company's public web infrastructure online, as well as building and maintaining an internal OpenShift-based application platform. In the past, he worked as a web developer, and previously maintained the internal Puppet infrastructure at Puppet. He uses the handle `thrnio` in various places around the internet.

--- a/speaker/ryan-whitehurst.md
+++ b/speaker/ryan-whitehurst.md
@@ -1,0 +1,5 @@
+## Ryan Whitehurst
+
+## Bio
+
+Ryan Whitehurst is a Site Reliability Engineer at Puppet. He helps to keep the company's public web infrastructure online, as well as building and maintaining an internal OpenShift-based application platform. In the past, he worked as a web developer, and previously maintained the internal Puppet infrastructure at Puppet. He uses the handle `thrnio` in various places around the internet.


### PR DESCRIPTION
This adds the abstract for the talk by Ryan Whitehurst, titled
"Reproducible Infrastructure with Terraform and Puppet", along with an
accompanying speaker bio.